### PR TITLE
[Merge] Play Record 기능 구현

### DIFF
--- a/Assets/00_Scripts/Play Record.meta
+++ b/Assets/00_Scripts/Play Record.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c6aff26b5cc4ae444aab385b39988e36
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00_Scripts/Play Record/PlayRecord.cs
+++ b/Assets/00_Scripts/Play Record/PlayRecord.cs
@@ -1,0 +1,173 @@
+using System.Text;
+using UnityEngine;
+
+// ==================================================================
+// 목적 : 전투 중 Player/Enemy의 행동 기록을 슬롯(1~3) 단위로 저장한다
+// 생성 일자 : 25/12/21
+// 최근 수정 일자 : 25/12/21
+// ==================================================================
+
+public class PlayRecord : MonoBehaviour
+{
+    /// <summary> 행위자 구분 </summary>
+    public enum Actor
+    {
+        Player = 0,
+        Enemy = 1
+    }
+
+    [Header("History Settings")]
+    [SerializeField, Range(5, 50)] private int windowSize = 15;
+
+    // [actor][slot][index]
+    private ActionCardData.ActionType[,,] _history;
+    private int[,] _writeIndex; // [actor][slot]
+    private int[,] _count;      // [actor][slot] 현재 저장된 개수
+
+    // [actor][slot][typeIndex] 카운트
+    private int[,,] _typeCounts;
+
+    private void Awake()
+    {
+        _history = new ActionCardData.ActionType[2, 3, windowSize];
+        _writeIndex = new int[2, 3];
+        _count = new int[2, 3];
+        _typeCounts = new int[2, 3, 3];
+    }
+
+    public void RecordPlayer(int slotIndex, ActionCardData.ActionType type) => Record(Actor.Player, slotIndex, type);
+    public void RecordEnemy(int slotIndex, ActionCardData.ActionType type) => Record(Actor.Enemy, slotIndex, type);
+
+    /// <summary>
+    /// 행위자와 슬롯 인덱스에 해당하는 기록을 저장한다.
+    /// </summary>
+    /// <param name="actor">행위자 (Player/Enemy)</param>
+    /// <param name="slotIndex">슬롯 인덱스 (0~2)</param>
+    /// <param name="type">행동 카드 타입</param>
+    public void Record(Actor actor, int slotIndex, ActionCardData.ActionType type)
+    {
+        if (slotIndex < 0 || slotIndex >= 3) return;
+
+        int a = (int)actor;
+        int t = ToTypeIndex(type);
+        if (t < 0) return;
+
+        // 꽉 찼으면 덮어쓰기 전 기존 값 제거
+        if (_count[a, slotIndex] >= windowSize)
+        {
+            int removeIndex = _writeIndex[a, slotIndex];
+            var oldType = _history[a, slotIndex, removeIndex];
+            int oldT = ToTypeIndex(oldType);
+            if (oldT >= 0) _typeCounts[a, slotIndex, oldT]--;
+        }
+        else
+        {
+            _count[a, slotIndex]++;
+        }
+
+        // 기록
+        int w = _writeIndex[a, slotIndex];
+        _history[a, slotIndex, w] = type;
+        _typeCounts[a, slotIndex, t]++;
+
+        _writeIndex[a, slotIndex] = (w + 1) % windowSize;
+    }
+    /// <summary>
+    /// 슬롯별 경향성 비율 추출
+    /// </summary>
+    /// <param name="actor">행위자 (Player/Enemy)</param>
+    /// <param name="slotIndex">슬롯 인덱스 (0~2)</param>
+    /// <param name="attackRate">공격 비율 출력</param>
+    /// <param name="defenseRate">방어 비율 출력</param>
+    /// <param name="healRate">회복 비율 출력</param>
+    // Stage 4 AI에서 쓰기 위한 “슬롯별 경향성 비율” (0~1)
+    public void GetTendency(Actor actor, int slotIndex, out float attackRate, out float defenseRate, out float healRate)
+    {
+        attackRate = defenseRate = healRate = 0f;
+        if (slotIndex < 0 || slotIndex >= 3) return;
+
+        int a = (int)actor;
+        int n = _count[a, slotIndex];
+        if (n <= 0) return;
+
+        attackRate = _typeCounts[a, slotIndex, 0] / (float)n;
+        defenseRate = _typeCounts[a, slotIndex, 1] / (float)n;
+        healRate = _typeCounts[a, slotIndex, 2] / (float)n;
+
+        Debug.Log($"[PlayRecord] {actor} Slot {slotIndex + 1} Tendency - " +
+            $"Attack: {attackRate:P0}, Defense: {defenseRate:P0}, Heal: {healRate:P0}");
+    }
+
+    /// <summary>
+    /// ActionType을 인덱스로 변환한다.
+    /// </summary>
+    /// <param name="type">행동 카드 타입</param>
+    private int ToTypeIndex(ActionCardData.ActionType type)
+    {
+        // 프로젝트의 ActionType이 Attack/Defense/Heal 이라는 전제
+        return type switch
+        {
+            ActionCardData.ActionType.Attack => 0,
+            ActionCardData.ActionType.Defense => 1,
+            ActionCardData.ActionType.Heal => 2,
+            _ => -1
+        };
+    }
+
+    #region Log Building
+    public string BuildLogForPlayer()
+    {
+        return BuildLog(Actor.Player);
+    }
+
+    public string BuildLogForEnemy()
+    {
+        return BuildLog(Actor.Enemy);
+    }
+    /// <summary>
+    /// 행위자별 로그 문자열 생성, StringBuilder 사용
+    /// </summary>
+    private string BuildLog(Actor actor)
+    {
+        var sb = new StringBuilder(512);
+
+        sb.AppendLine("====================================");
+        sb.AppendLine($"[PlayRecord] {(actor == Actor.Player ? "PLAYER" : "ENEMY")} ACTION LOG");
+        sb.AppendLine("====================================");
+
+        int a = (int)actor;
+
+        for (int slot = 0; slot < 3; slot++)
+        {
+            sb.AppendLine($"-- Slot {slot + 1} --");
+
+            int count = _count[a, slot];
+            if (count == 0)
+            {
+                sb.AppendLine("  (no records)");
+                continue;
+            }
+
+            // 최근 기록 출력 (오래된 → 최신)
+            sb.Append("  Recent : ");
+            for (int i = 0; i < count; i++)
+            {
+                int index = (_writeIndex[a, slot] - count + i + windowSize) % windowSize;
+                sb.Append(_history[a, slot, index]);
+                if (i < count - 1) sb.Append(" -> ");
+            }
+            sb.AppendLine();
+
+            // 비율 출력
+            float atk = _typeCounts[a, slot, 0] / (float)count;
+            float def = _typeCounts[a, slot, 1] / (float)count;
+            float heal = _typeCounts[a, slot, 2] / (float)count;
+
+            sb.AppendLine($"  Rate   : Attack {atk:P0}, Defense {def:P0}, Heal {heal:P0}");
+        }
+
+        sb.AppendLine("====================================");
+        return sb.ToString();
+    }
+    #endregion
+}

--- a/Assets/00_Scripts/Play Record/PlayRecord.cs.meta
+++ b/Assets/00_Scripts/Play Record/PlayRecord.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e7c73b1eb6a2404483ccebc6dfe685c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00_Scripts/Play Record/PlayRecordDebugger.cs
+++ b/Assets/00_Scripts/Play Record/PlayRecordDebugger.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+// ==================================================================
+// 목적 : PlayRecord의 행동 기록을 키 입력으로 콘솔에 출력한다
+// 생성 일자 : 25/12/21
+// 최근 수정 일자 : 25/12/21
+// ==================================================================
+
+public class PlayRecordDebugInput : MonoBehaviour
+{
+    [SerializeField] private PlayRecord playRecord;
+
+    private void Update()
+    {
+        if (playRecord == null) return;
+
+        if (Input.GetKeyDown(KeyCode.Q))
+        {
+            Debug.Log(playRecord.BuildLogForPlayer());
+        }
+        
+        if (Input.GetKeyDown(KeyCode.W))
+        {
+            Debug.Log(playRecord.BuildLogForEnemy());
+        }
+    }
+}

--- a/Assets/00_Scripts/Play Record/PlayRecordDebugger.cs.meta
+++ b/Assets/00_Scripts/Play Record/PlayRecordDebugger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 646a55fad3d272e4f92dfe95e64b4414
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00_Scripts/Turn System/GameCycle.cs
+++ b/Assets/00_Scripts/Turn System/GameCycle.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 // ==================================================================
 // 목적 : 플레이어 턴 시작/행동 결정/종료 및 AI 턴 진행 흐름을 관리하는 턴 상태 클래스 모음
 // 생성 일자 : 25/12/08
-// 최근 수정 일자 : 25/12/20
+// 최근 수정 일자 : 25/12/21
 // ==================================================================
 
 
@@ -136,6 +136,10 @@ public class BattleLoopState : TurnStateBase
             var pCard = (playerCards != null && i < playerCards.Count) ? playerCards[i] : null;
             Debug.Log($"[Cycle {i + 1}] Player 행동: {(pCard != null ? pCard.CardName : "None")}");
 
+            // [25/12/21] 슬롯별 기록 저장 (Player)
+            if (pCard != null && ctx.playRecord != null)
+                ctx.playRecord.RecordPlayer(i, pCard.Type);
+
             if (pCard != null)
                 ActionCardExecutor.Execute(pCard, ctx.playerCharactor, ctx.enemyCharactor,ctx ,isPlayer : true);
 
@@ -152,6 +156,10 @@ public class BattleLoopState : TurnStateBase
             // ---------- AI Action ----------
             var aCard = (ctx.aiPlannedCards != null && i < ctx.aiPlannedCards.Length) ? ctx.aiPlannedCards[i] : null;
             Debug.Log($"[Cycle {i + 1}] AI 행동: {(aCard != null ? aCard.CardName : "None")}");
+
+            // [25/12/21] 슬롯별 기록 저장 (Enemy)
+            if (aCard != null && ctx.playRecord != null)
+                ctx.playRecord.RecordEnemy(i, aCard.Type);
 
             if (aCard != null)
                 ActionCardExecutor.Execute(aCard, ctx.enemyCharactor, ctx.playerCharactor,ctx ,isPlayer : false);

--- a/Assets/00_Scripts/Turn System/TurnController.cs
+++ b/Assets/00_Scripts/Turn System/TurnController.cs
@@ -5,7 +5,7 @@ using UnityEngine.UI;
 // ==================================================================
 // 목적 : UI 입력과 상태 머신을 연결하여 턴 진행을 제어하는 프레젠테이션 레이어 컨트롤러
 // 생성 일자 : 25/12/08
-// 최근 수정 일자 : 25/12/17
+// 최근 수정 일자 : 25/12/21
 // ==================================================================
 
 /// <summary>
@@ -34,6 +34,10 @@ public class TurnController : MonoBehaviour
     [Header("AI Weight Config")]
     [SerializeField] private AIWeightData defaultAiWeights;
     [SerializeField] private AIWeightOverrideProvider aiWeightOverride;
+
+    // 25/12/21 추가 : 플레이 기록 저장소 주입
+    [Header("Game Record")]
+    [SerializeField] private PlayRecord playRecord;
 
     #endregion
 
@@ -84,6 +88,9 @@ public class TurnController : MonoBehaviour
             aiDefenseWeight = def,
             // [25/12/19] 추가 : AI 회복 행동 가중치 주입
             aiHealWeight = heal,
+
+            // 25/12/21 추가 : 플레이 기록 저장소 주입
+            playRecord = playRecord,
         };
 
         _machine = new TurnStateMachine();
@@ -97,6 +104,14 @@ public class TurnController : MonoBehaviour
         $"HealWeight={_context.aiHealWeight}, " +
         $"OverrideUsed={aiWeightOverride != null && aiWeightOverride.useOverride}"
         );
+
+        // [25/12/21] 추가 : 슬롯별 가중치 배열 초기화
+        for (int i = 0; i < 3; i++)
+        {
+            _context.aiAttackWeightsBySlot[i] = _context.aiAttackWeight;
+            _context.aiDefenseWeightsBySlot[i] = _context.aiDefenseWeight;
+            _context.aiHealWeightsBySlot[i] = _context.aiHealWeight;
+        }
     }
 
     /// <summary>

--- a/Assets/00_Scripts/Turn System/TurnSystemBase.cs
+++ b/Assets/00_Scripts/Turn System/TurnSystemBase.cs
@@ -7,7 +7,7 @@ using UnityEngine.UI;
 // ==================================================================
 // 목적 : 턴 진행에 필요한 컨텍스트(TurnContext)와 턴 상태 기초 클래스, 상태 머신의 기반 구조를 제공
 // 생성 일자 : 25/12/08
-// 최근 수정 일자 : 25/12/20
+// 최근 수정 일자 : 25/12/21
 // ==================================================================
 
 /// <summary>
@@ -54,6 +54,36 @@ public class TurnContext
 
     // 25/12/20 추가 : AI 의사 결정 횟수 추적
     public int aiDecisionCount;
+
+    // 25/12/21 추가 : 슬롯별 AI 행동 가중치 ( Stage 4 AI에서 사용 )
+    public float[] aiAttackWeightsBySlot = new float[3];
+    public float[] aiDefenseWeightsBySlot = new float[3];
+    public float[] aiHealWeightsBySlot = new float[3];
+
+    // 25/12/21 추가 : 전투 중 플레이 기록 저장소(씬 오브젝트)
+    public PlayRecord playRecord;
+    
+    // 25/12/21 추가 : 슬롯별 AI 행동 가중치 조회 헬퍼
+    public float GetAiAttackWeight(int slotIndex)
+    {
+        if (aiAttackWeightsBySlot != null && aiAttackWeightsBySlot.Length == 3)
+            return aiAttackWeightsBySlot[slotIndex];
+        return aiAttackWeight; // 기존 단일 가중치 fallback
+    }
+
+    public float GetAiDefenseWeight(int slotIndex)
+    {
+        if (aiDefenseWeightsBySlot != null && aiDefenseWeightsBySlot.Length == 3)
+            return aiDefenseWeightsBySlot[slotIndex];
+        return aiDefenseWeight;
+    }
+
+    public float GetAiHealWeight(int slotIndex)
+    {
+        if (aiHealWeightsBySlot != null && aiHealWeightsBySlot.Length == 3)
+            return aiHealWeightsBySlot[slotIndex];
+        return aiHealWeight;
+    }
 }
 
 /// <summary>

--- a/Assets/01_Scenes/TurnSystemScene.unity
+++ b/Assets/01_Scenes/TurnSystemScene.unity
@@ -122,6 +122,37 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &143407395
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 143407396}
+  m_Layer: 0
+  m_Name: =====Debugger=====
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &143407396
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 143407395}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 960.5963, y: 541.47455, z: 1.5737507}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &225087635
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -582,8 +613,9 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 476966047}
+  - component: {fileID: 476966048}
   m_Layer: 0
-  m_Name: Player Record
+  m_Name: Play Record
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -604,6 +636,19 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &476966048
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 476966046}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e7c73b1eb6a2404483ccebc6dfe685c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  windowSize: 15
 --- !u!1 &667408192
 GameObject:
   m_ObjectHideFlags: 0
@@ -1236,6 +1281,37 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1023475494}
   m_CullTransparentMesh: 1
+--- !u!1 &1032645486
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1032645487}
+  m_Layer: 0
+  m_Name: =====Game Record=====
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1032645487
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1032645486}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 960.5963, y: 541.47455, z: 1.5737507}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1069411955 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6851376899444788997, guid: 58ff90f8c22e68b4bbc57995cfdacd0c,
@@ -1260,6 +1336,51 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 860caac5ee44f374bbd51e0cb8d93462, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1312687248
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1312687250}
+  - component: {fileID: 1312687249}
+  m_Layer: 0
+  m_Name: Play Record Deugger
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1312687249
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1312687248}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 646a55fad3d272e4f92dfe95e64b4414, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playRecord: {fileID: 476966048}
+--- !u!4 &1312687250
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1312687248}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 960.5963, y: 541.47455, z: 1.5737507}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1373054496
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1677,6 +1798,7 @@ MonoBehaviour:
   enemyCharactorUI: {fileID: 1239367056}
   defaultAiWeights: {fileID: 11400000, guid: 34ca9129fead6d04aa9efa157bc0cd71, type: 2}
   aiWeightOverride: {fileID: 942760287}
+  playRecord: {fileID: 476966048}
 --- !u!4 &1565185801
 Transform:
   m_ObjectHideFlags: 0
@@ -2744,5 +2866,8 @@ SceneRoots:
   - {fileID: 667408193}
   - {fileID: 354212509}
   - {fileID: 942760288}
+  - {fileID: 1032645487}
   - {fileID: 476966047}
+  - {fileID: 143407396}
   - {fileID: 1972023114}
+  - {fileID: 1312687250}


### PR DESCRIPTION
## 요약

- Player / Enemy의 행동을 Cycle(슬롯) 단위로 기록하는 Play Record 시스템 추가

- 행동 기록 기준을 전투 실행 시점으로 통일하여 데이터 정합성 확보

- Stage 4 AI 판단(행동 경향성 분석)을 위한 기초 데이터 수집 구조 완성
---
### 1. Play Record 시스템 추가

- `PlayRecord `(신규)

  - Player / Enemy의 행동을 슬롯(1~3 Cycle) 단위로 분리하여 저장

  - (슬롯, 행동 타입) 기반 기록 구조 적용

  - 슬라이딩 윈도우 방식으로 최근 행동 기록 유지

  - 슬롯별 Attack / Defense / Heal 비율 계산 기능 제공

### 2. 행동 기록 시점 정합성 개선

- `GameCycle `/ `BattleLoopState `(수정)

  - Player 행동 기록을 Cycle 실행 시점 기준으로 저장

  - 실제로 실행된 카드(`ActionCardData`)를 기준으로 기록

- `AIPlanner `(수정)

  - AI 행동 기록을 Plan 단계에서 제거

  - 행동 기록 책임을 전투 실행 단계로 이동

- `GameCycle `/ `BattleLoopState `(수정)

  - AI 행동 역시 Player와 동일하게 Cycle 실행 시점 기준으로 기록

### 3. 디버그 로그 출력 기능 추가

- `PlayRecord `(수정)

  - **StringBuilder** 기반 행동 기록 로그 생성 기능 추가

  - 슬롯별 최근 행동 흐름 및 행동 비율 출력 지원

- `PlayRecordDebugger `(신규)

  - 키 입력 기반 디버그 출력 기능 추가

    - Q : Player 행동 기록 출력

    - W : Enemy 행동 기록 출력