### PR TITLE
[Issue, Fix] Issue #20 방어 카드 미 적용 문제 해결

### DIFF
--- a/Assets/00_Scripts/Turn System/Turn Cycle/05_BattleLoopState.cs
+++ b/Assets/00_Scripts/Turn System/Turn Cycle/05_BattleLoopState.cs
@@ -32,7 +32,8 @@ public class BattleLoopState : TurnStateBase
     private IEnumerator ExecuteLoopCo()
     {
         var playerCards = ctx.selectedAreaManager != null ? ctx.selectedAreaManager.SelectedCards : null;
-
+        
+        // [25/12/31] 추가: 플레이어 및 AI 카드 유효성 검사, 기존에 매번 체크하던 것을 한번에 처리
         if(playerCards == null && (ctx.aiPlannedCards == null || ctx.aiPlannedCards.Length == 0))
         {
             Debug.LogWarning("전투 사이클 실행 불가: 플레이어 및 AI 카드 없음");

--- a/Assets/00_Scripts/Turn System/Turn Cycle/05_BattleLoopState.cs
+++ b/Assets/00_Scripts/Turn System/Turn Cycle/05_BattleLoopState.cs
@@ -33,6 +33,12 @@ public class BattleLoopState : TurnStateBase
     {
         var playerCards = ctx.selectedAreaManager != null ? ctx.selectedAreaManager.SelectedCards : null;
 
+        if(playerCards == null && (ctx.aiPlannedCards == null || ctx.aiPlannedCards.Length == 0))
+        {
+            Debug.LogWarning("전투 사이클 실행 불가: 플레이어 및 AI 카드 없음");
+            yield break;
+        }
+
         for (int i = 0; i < 3; i++)
         {
             // cycle 플래그 초기화
@@ -44,23 +50,22 @@ public class BattleLoopState : TurnStateBase
             // 25/12/31 추가: 전투 사이클 텍스트 업데이트
             ctx.battleCycleText.text = $"Battle Cycle {i + 1} / 3";
 
-            var pCard = (playerCards != null && i < playerCards.Count) ? playerCards[i] : null;
-            var aCard = (ctx.aiPlannedCards != null && i < ctx.aiPlannedCards.Length) ? ctx.aiPlannedCards[i] : null;
+            var pCard = (i < playerCards.Count) ? playerCards[i] : null;
+            var aCard = (i < ctx.aiPlannedCards.Length) ? ctx.aiPlannedCards[i] : null;
 
-            Debug.Log($"[Cycle {i + 1}] Player 행동: {(pCard != null ? pCard.CardName : "None")}");
-            Debug.Log($"[Cycle {i + 1}] AI 행동: {(aCard != null ? aCard.CardName : "None")}");
+            Debug.Log($"[Cycle {i + 1}] Player 행동: {pCard.CardName}");
+            Debug.Log($"[Cycle {i + 1}] AI 행동: {aCard.CardName}");
 
-
-            if (pCard != null)
-                yield return ctx.playerAnim.PlayAndWaitIdle(ToAnimType(pCard.Type));
-
-            if (aCard != null)
-                yield return ctx.enemyAnim.PlayAndWaitIdle(ToAnimType(aCard.Type));
-
+            // 1) 애니메이션 재생 및 대기
+            yield return ctx.playerAnim.PlayAndWaitIdle(ToAnimType(pCard.Type));
+            yield return ctx.enemyAnim.PlayAndWaitIdle(ToAnimType(aCard.Type));
 
             // 2) 기록 저장
-            if (pCard != null && ctx.playRecord != null) ctx.playRecord.RecordPlayer(i, pCard.Type);
-            if (aCard != null && ctx.playRecord != null) ctx.playRecord.RecordEnemy(i, aCard.Type);
+            if (ctx.playRecord != null)
+            {
+                ctx.playRecord.RecordPlayer(i, pCard.Type);
+                ctx.playRecord.RecordEnemy(i, aCard.Type);
+            }
 
             // 3) 먼저 방어/회복 같은 상태 세팅을 먼저 처리
             if (pCard.EffectData.Type != ActionCardEffectData.EffectType.Attack)
@@ -121,7 +126,7 @@ public class BattleLoopState : TurnStateBase
 
     private void ApplyHealDelta(CharactorData unit, bool opponentUsedAttack)
     {
-        int delta = opponentUsedAttack ? -2 : +2;
+        int delta = opponentUsedAttack ? -1 : +2;
         unit.SetHealth(Mathf.Max(0, unit.GetHealth() + delta));
         Debug.Log($"[Heal] {unit.name} delta={delta}");
     }

--- a/Assets/00_Scripts/Turn System/Turn Cycle/05_BattleLoopState.cs
+++ b/Assets/00_Scripts/Turn System/Turn Cycle/05_BattleLoopState.cs
@@ -62,11 +62,21 @@ public class BattleLoopState : TurnStateBase
             if (pCard != null && ctx.playRecord != null) ctx.playRecord.RecordPlayer(i, pCard.Type);
             if (aCard != null && ctx.playRecord != null) ctx.playRecord.RecordEnemy(i, aCard.Type);
 
-            // 3) 효과 적용(Resolve) - 기존과 동일
-            if (pCard != null) ActionCardExecutor.Execute(pCard, ctx.playerCharactor, ctx.enemyCharactor, ctx, isPlayer: true);
-            if (aCard != null) ActionCardExecutor.Execute(aCard, ctx.enemyCharactor, ctx.playerCharactor, ctx, isPlayer: false);
+            // 3) 먼저 방어/회복 같은 상태 세팅을 먼저 처리
+            if (pCard.EffectData.Type != ActionCardEffectData.EffectType.Attack)
+                ActionCardExecutor.Execute(pCard, ctx.playerCharactor, ctx.enemyCharactor, ctx, isPlayer: true);
 
-            // 4) 사이클 종료 처리(Heal/UI/종료)
+            if (aCard.EffectData.Type != ActionCardEffectData.EffectType.Attack)
+                ActionCardExecutor.Execute(aCard, ctx.enemyCharactor, ctx.playerCharactor, ctx, isPlayer: false);
+
+            // 4) 그 다음 공격을 처리
+            if (pCard.EffectData.Type == ActionCardEffectData.EffectType.Attack)
+                ActionCardExecutor.Execute(pCard, ctx.playerCharactor, ctx.enemyCharactor, ctx, isPlayer: true);
+
+            if (aCard.EffectData.Type == ActionCardEffectData.EffectType.Attack)
+                ActionCardExecutor.Execute(aCard, ctx.enemyCharactor, ctx.playerCharactor, ctx, isPlayer: false);
+
+            // 5) 사이클 종료 처리(Heal/UI/종료)
             ApplyHealAtEndOfCycle();
             ctx.playerCharactorUI.UpdateHealthUI();
             ctx.enemyCharactorUI.UpdateHealthUI();

--- a/Assets/AddressableAssetsData/AssetGroups/Card_Data.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Card_Data.asset
@@ -41,7 +41,8 @@ MonoBehaviour:
   - m_GUID: 8c3e279e70e88224a83bf8ad54f02476
     m_Address: Default AI Weight/Attack, Defense, Heal
     m_ReadOnly: 0
-    m_SerializedLabels: []
+    m_SerializedLabels:
+    - card_data
     FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 98d30c958649c164b86a60ad791aa19a
     m_Address: Card/Heal


### PR DESCRIPTION
## Link : [첫 턴에 방어 카드가 적용이 되지 않는 문제](https://github.com/hangil2010/CardTactics/issues/20)

## Issue

- 전투 Cycle 내에서 Attack / Defense 카드가 동시에 사용될 경우, 첫 Cycle에서 Defense 카드가 정상적으로 적용되지 않는 문제 발생

- Resolve 단계에서 카드 효과를 플레이어 카드 → AI 카드 순서로 즉시 실행하는 구조로 되어 있었음

- `ActionCardExecutor` 내부 처리 방식상 Attack 카드는 즉시 데미지를 적용, Defense 카드는 Guard 상태를 세팅

- 이로 인해 Attack 카드가 Defense 카드보다 먼저 Resolve될 경우, Guard 상태가 적용되기 전에 데미지가 들어가 방어 효과가 무효화됨

- 즉, 카드 데이터나 로직 오류가 아닌 Resolve 실행 순서로 인한 구조적 문제

## Fix

- Resolve 단계를 `BattleLoopState`에서 분리하여 처리하도록 수정

- 카드 효과를 다음 순서로 실행

  - 1차 Resolve : Defense / Heal 등 상태 세팅용 카드 효과를 먼저 처리

  - 2차 Resolve : Attack 카드의 데미지 처리 수행

- 이를 통해 같은 Cycle 내에서 Defense,Heal 카드가 항상 Attack 처리 이전에 적용되도록 보장

- `ActionCardExecutor`의 내부 구조는 유지하면서 Resolve 호출 순서만으로 문제를 해결하여 변경 범위를 최소화

- 결과적으로 모든 카드 조합에서 방어 카드가 정상 동작함을 확인

## Misc
- 여러 곳에 분산되어 있던 null 체크 로직을 공통 흐름으로 정리
- 중복 조건문을 제거하여 코드 가독성과 안정성 개선